### PR TITLE
More descriptive error when make repayment using wrong token

### DIFF
--- a/src/modules/Dashboard/Debts/ActiveDebtOrder/ActiveDebtOrder.tsx
+++ b/src/modules/Dashboard/Debts/ActiveDebtOrder/ActiveDebtOrder.tsx
@@ -109,7 +109,11 @@ class ActiveDebtOrder extends React.Component<Props, State> {
                 this.setState({ makeRepayment: false, awaitingRepaymentTx: false });
 
                 if (errors.length > 0) {
-                    this.props.handleSetErrorToast(errors[0]);
+					if (this.props.debtOrder.principalTokenSymbol !== tokenSymbol) {
+						this.props.handleSetErrorToast(`Repayments to debt agreement ${shortenString(this.props.debtOrder.issuanceHash)} must be made in ${this.props.debtOrder.principalTokenSymbol}`);
+					} else {
+						this.props.handleSetErrorToast(errors[0]);
+					}
                 } else {
                     this.props.handleSuccessfulRepayment(
                         this.props.debtOrder.issuanceHash,


### PR DESCRIPTION
This PR introduces the following change:

- Display more descriptive error when user makes a repayment to a debt agreement using the wrong token type