### PR TITLE
Loan has wrong status on Debts/Investments tabs

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "identicon.js": "^2.3.1",
     "jest": "20.0.4",
     "lodash.compact": "^3.0.1",
+    "moment": "^2.22.0",
     "ngrok": "^2.2.26",
     "object-assign": "4.1.1",
     "postcss-flexbugs-fixes": "3.2.0",

--- a/src/modules/Dashboard/Debts/DebtOrderHistory/DebtOrderRow.tsx
+++ b/src/modules/Dashboard/Debts/DebtOrderHistory/DebtOrderRow.tsx
@@ -50,7 +50,7 @@ class DebtOrderRow extends React.Component<Props, State> {
 						{shortenString(debtOrder.issuanceHash)}
 					</Col>
 					<Col xs="3" md="4">
-						{debtOrder.principalAmount.eq(debtOrder.repaidAmount) ? 'Paid' : 'Delinquent'}
+						{debtOrder.repaidAmount.gte(debtOrder.principalAmount) ? 'Paid' : 'Delinquent'}
 					</Col>
 					<Col xs="3" md="4">
 						Simple Interest Loan (Non-Collateralized)

--- a/src/modules/Dashboard/Debts/DebtOrderHistory/DebtOrderRowContainer.tsx
+++ b/src/modules/Dashboard/Debts/DebtOrderHistory/DebtOrderRowContainer.tsx
@@ -1,0 +1,18 @@
+import { connect } from 'react-redux';
+import { DebtOrderRow } from './DebtOrderRow';
+
+const mapStateToProps = (state: any) => {
+	return {
+		dharma: state.dharmaReducer.dharma
+	};
+};
+
+const mapDispatchToProps = (dispatch: any) => {
+	return {
+	};
+};
+
+export const DebtOrderRowContainer = connect(
+	mapStateToProps,
+	mapDispatchToProps
+)(DebtOrderRow);

--- a/src/modules/Dashboard/Debts/DebtOrderHistory/index.tsx
+++ b/src/modules/Dashboard/Debts/DebtOrderHistory/index.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { DebtOrderEntity } from '../../../../models';
 // import { formatDate } from '../../../../utils';
 import { Col } from 'reactstrap';
-import { DebtOrderRow } from './DebtOrderRow';
+import { DebtOrderRowContainer } from './DebtOrderRowContainer';
 import {
 	Wrapper,
 	Title,
@@ -35,7 +35,7 @@ class DebtOrderHistory extends React.Component<Props, {}> {
 				</TableHeaderRow>
 				{
 					debtOrders.map((debtOrder) => (
-						<DebtOrderRow debtOrder={debtOrder} key={debtOrder.issuanceHash} />
+						<DebtOrderRowContainer debtOrder={debtOrder} key={debtOrder.issuanceHash} />
 					))
 				}
 			</Wrapper>

--- a/src/modules/Dashboard/Investments/InvestmentHistory/InvestmentRow.tsx
+++ b/src/modules/Dashboard/Investments/InvestmentHistory/InvestmentRow.tsx
@@ -47,7 +47,7 @@ class InvestmentRow extends React.Component<Props, State> {
 						{shortenString(investment.issuanceHash)}
 					</Col>
 					<Col xs="3" md="4">
-						{investment.principalAmount.eq(investment.earnedAmount) ? 'Paid' : 'Delinquent'}
+						{investment.earnedAmount.gte(investment.principalAmount) ? 'Paid' : 'Delinquent'}
 					</Col>
 					<Col xs="3" md="4">
 						Simple Interest Loan (Non-Collateralized)

--- a/src/modules/Dashboard/Investments/InvestmentHistory/InvestmentRowContainer.tsx
+++ b/src/modules/Dashboard/Investments/InvestmentHistory/InvestmentRowContainer.tsx
@@ -1,0 +1,18 @@
+import { connect } from 'react-redux';
+import { InvestmentRow } from './InvestmentRow';
+
+const mapStateToProps = (state: any) => {
+	return {
+		dharma: state.dharmaReducer.dharma
+	};
+};
+
+const mapDispatchToProps = (dispatch: any) => {
+	return {
+	};
+};
+
+export const InvestmentRowContainer = connect(
+	mapStateToProps,
+	mapDispatchToProps
+)(InvestmentRow);

--- a/src/modules/Dashboard/Investments/InvestmentHistory/index.tsx
+++ b/src/modules/Dashboard/Investments/InvestmentHistory/index.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { InvestmentEntity } from '../../../../models';
 // import { formatDate } from '../../../../utils';
 import { Col } from 'reactstrap';
-import { InvestmentRow } from './InvestmentRow';
+import { InvestmentRowContainer } from './InvestmentRowContainer';
 import {
 	Wrapper,
 	Title,
@@ -35,7 +35,7 @@ class InvestmentHistory extends React.Component<Props, {}> {
 				</TableHeaderRow>
 				{
 					investments.map((investment) => (
-						<InvestmentRow investment={investment} key={investment.issuanceHash} />
+						<InvestmentRowContainer investment={investment} key={investment.issuanceHash} />
 					))
 				}
 			</Wrapper>

--- a/yarn.lock
+++ b/yarn.lock
@@ -5090,7 +5090,7 @@ mocha@^3.4.2:
     mkdirp "0.5.1"
     supports-color "3.1.2"
 
-moment@^2.20.1:
+moment@^2.20.1, moment@^2.22.0:
   version "2.22.0"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.22.0.tgz#7921ade01017dd45186e7fee5f424f0b8663a730"
 


### PR DESCRIPTION
This PR introduces the following change:

- Fixes the loan that has status of Delinquent even though it was repaid ahead of time