### PR TITLE
Set Description max char limit and fix oneOf error

### DIFF
--- a/src/components/Form/JSONSchemaForm/index.tsx
+++ b/src/components/Form/JSONSchemaForm/index.tsx
@@ -23,6 +23,7 @@ interface Props {
 	onHandleChange: (formData: any) => void;
 	onHandleSubmit: () => void;
 	validate?: (formData: any, errors: any) => any;
+	transformErrors?: (errors: any[]) => any[];
 }
 
 const widgets = {
@@ -440,6 +441,7 @@ class JSONSchemaForm extends React.Component<Props, {}> {
 				showErrorList={false}
 				widgets={widgets}
 				validate={this.props.validate}
+				transformErrors={this.props.transformErrors}
 			>
 				<FieldWrapper className="field-wrapper button-container">
 					<Button type="submit" className="button">{this.props.buttonText || 'Submit'}</Button>

--- a/src/modules/RequestLoan/RequestLoanForm/RequestLoanForm.tsx
+++ b/src/modules/RequestLoan/RequestLoanForm/RequestLoanForm.tsx
@@ -38,6 +38,7 @@ class RequestLoanForm extends React.Component<Props, State> {
         this.handleSignDebtOrder = this.handleSignDebtOrder.bind(this);
         this.confirmationModalToggle = this.confirmationModalToggle.bind(this);
         this.validateForm = this.validateForm.bind(this);
+		this.transformErrors = this.transformErrors.bind(this);
 
         this.state = {
             formData: {},
@@ -191,6 +192,15 @@ class RequestLoanForm extends React.Component<Props, State> {
         return errors;
     }
 
+	transformErrors(errors: any[]) {
+		return errors.map(error => {
+			if (error.name === "oneOf") {
+				error.message = "Please fix the errors above";
+			}
+			return error;
+		});
+	}
+
     render() {
         const confirmationModalContent = (
             <span>
@@ -218,15 +228,16 @@ class RequestLoanForm extends React.Component<Props, State> {
             <PaperLayout>
                 <MainWrapper>
                     <Header title={"Request a Loan"} description={descriptionContent} />
-                    <JSONSchemaForm
-                        schema={schema}
-                        uiSchema={uiSchema}
-                        formData={this.state.formData}
-                        buttonText="Generate Debt Order"
-                        onHandleChange={this.handleChange}
-                        onHandleSubmit={this.handleSubmit}
-                        validate={this.validateForm}
-                    />
+					<JSONSchemaForm
+						schema={schema}
+						uiSchema={uiSchema}
+						formData={this.state.formData}
+						buttonText="Generate Debt Order"
+						onHandleChange={this.handleChange}
+						onHandleSubmit={this.handleSubmit}
+						validate={this.validateForm}
+						transformErrors={this.transformErrors}
+					/>
                 </MainWrapper>
                 <ConfirmationModal
                     modal={this.state.confirmationModal}

--- a/src/modules/RequestLoan/RequestLoanForm/schema.tsx
+++ b/src/modules/RequestLoan/RequestLoanForm/schema.tsx
@@ -63,6 +63,7 @@ export const schema: JSONSchema4 = {
 								},
 								description: {
 									type: 'string',
+									maxLength: 500
 								}
 							}
 						},


### PR DESCRIPTION
This PR introduces the following changes:

- Set char limit to 500 for the `Description` field on Request order form. Bitly's `shorten` API will fail if we pass a very long url.
- Add `transformErrors` prop in JSONSchemaForm to transform default validation error from JSONSchemaForm to a friendlier error message.
