### PR TITLE
Fix cancel open debt order bug

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -51,6 +51,7 @@ class App extends React.Component<Props, State> {
         }
         const latestAccounts = await promisify(web3.eth.getAccounts)();
         if (latestAccounts.length && accounts.length && latestAccounts[0] !== accounts[0]) {
+			localStorage.clear();
             window.location.reload();
         }
     }


### PR DESCRIPTION
This PR introduces the following changes:

- Clear local storage when switching account on Metamask. This is to prevent populating the other account's open debt orders on this newly signed in account.
- Add extra check, i.e `debtOrder.debtor === accounts[0]` before canceling the debt order