### PR TITLE
Remove debt order from the pending list if it's filled

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -39,12 +39,6 @@ class App extends React.Component<Props, State> {
         clearInterval(this.state.intervalId);
     }
 
-    componentWillReceiveProps(nextProps: Props) {
-        if (nextProps.web3 && nextProps.accounts) {
-            this.checkAccount(nextProps.web3, nextProps.accounts);
-        }
-    }
-
     async checkAccount(web3: Web3, accounts: string[]) {
         if (!web3 || !accounts) {
             return;

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -26,8 +26,8 @@ class Toast extends React.Component<Props, State> {
 		this.onDismiss = this.onDismiss.bind(this);
 	}
 
-	componentWillReceiveProps(nextProps: Props) {
-		if (this.props.message !== nextProps.message && nextProps.message) {
+	componentDidUpdate(prevProps: Props) {
+		if (this.props.message !== prevProps.message && this.props.message) {
 			this.setState({ visible: true });
 			setTimeout(() => {
 				this.setState({ visible: false });

--- a/src/components/TradingPermissions/TradingPermissions.tsx
+++ b/src/components/TradingPermissions/TradingPermissions.tsx
@@ -52,9 +52,9 @@ class TradingPermissions extends React.Component<Props, State> {
         this.getTokenData(this.props.dharma);
     }
 
-    componentWillReceiveProps(nextProps: Props) {
-        if (!this.props.dharma && nextProps.dharma) {
-            this.getTokenData(nextProps.dharma);
+    componentDidUpdate(prevProps: Props) {
+		if (this.props.dharma !== prevProps.dharma) {
+            this.getTokenData(this.props.dharma);
         }
     }
 

--- a/src/modules/Dashboard/Dashboard.tsx
+++ b/src/modules/Dashboard/Dashboard.tsx
@@ -48,10 +48,10 @@ class Dashboard extends React.Component<Props, States> {
 		}
 	}
 
-	async componentWillReceiveProps(nextProps: Props) {
-		if (this.props.dharma !== nextProps.dharma) {
-			await this.getDebtsAsync(nextProps.dharma);
-			await this.getInvestmentsAsync(nextProps.dharma);
+	async componentDidUpdate(prevProps: Props) {
+		if (this.props.dharma !== prevProps.dharma) {
+			await this.getDebtsAsync(this.props.dharma);
+			await this.getInvestmentsAsync(this.props.dharma);
 			this.setState({ initiallyLoading: false });
 		}
 	}

--- a/src/modules/Dashboard/DashboardContainer.ts
+++ b/src/modules/Dashboard/DashboardContainer.ts
@@ -3,6 +3,7 @@ import { Dashboard } from "./Dashboard";
 import { setError } from "../../components/Toast/actions";
 import { setFilledDebtOrders } from "./actions";
 import { DebtOrderEntity } from "../../models";
+import { fillDebtOrder } from "../FillLoan/FillLoanEntered/actions";
 
 const mapStateToProps = (state: any) => {
     return {
@@ -17,7 +18,8 @@ const mapDispatchToProps = (dispatch: any) => {
     return {
         handleSetError: (errorMessage: string) => dispatch(setError(errorMessage)),
         handleSetFilledDebtOrders: (filledDebtOrders: DebtOrderEntity[]) =>
-            dispatch(setFilledDebtOrders(filledDebtOrders))
+			dispatch(setFilledDebtOrders(filledDebtOrders)),
+		handleFillDebtOrder: (issuanceHash: string) => dispatch(fillDebtOrder(issuanceHash))
     };
 };
 

--- a/src/modules/Dashboard/Debts/DebtOrderHistory/DebtOrderRow.tsx
+++ b/src/modules/Dashboard/Debts/DebtOrderHistory/DebtOrderRow.tsx
@@ -38,18 +38,20 @@ class DebtOrderRow extends React.Component<Props, State> {
 	}
 
 	async componentDidMount() {
-		if (this.props.dharma && this.props.debtOrder) {
-			await this.determineStatus(this.props.dharma, this.props.debtOrder);
+		await this.determineStatus(this.props.dharma);
+	}
+
+	async componentDidUpdate(prevProps: Props) {
+		if (this.props.dharma !== prevProps.dharma) {
+			await this.determineStatus(this.props.dharma);
 		}
 	}
 
-	async componentWillReceiveProps(nextProps: Props) {
-		if (nextProps.dharma && nextProps.debtOrder) {
-			await this.determineStatus(nextProps.dharma, nextProps.debtOrder);
+	async determineStatus(dharma: Dharma) {
+		const { debtOrder } = this.props;
+		if (!dharma || !debtOrder) {
+			return;
 		}
-	}
-
-	async determineStatus(dharma: Dharma, debtOrder: DebtOrderEntity) {
 		const valueRepaid = await dharma.servicing.getValueRepaid(debtOrder.issuanceHash);
 		const expectedRepaidAmount = await dharma.servicing.getExpectedValueRepaid(debtOrder.issuanceHash, moment().unix());
 		this.setState({

--- a/src/modules/Dashboard/Debts/Debts.tsx
+++ b/src/modules/Dashboard/Debts/Debts.tsx
@@ -33,8 +33,10 @@ class Debts extends React.Component<Props, State> {
         this.getDebtOrdersDetails(this.props.debtOrders);
     }
 
-    componentWillReceiveProps(nextProps: Props) {
-        this.getDebtOrdersDetails(nextProps.debtOrders);
+    componentDidUpdate(prevProps: Props) {
+		if (this.props.debtOrders !== prevProps.debtOrders) {
+			this.getDebtOrdersDetails(this.props.debtOrders);
+		}
     }
 
     getDebtOrdersDetails(debtOrders: DebtOrderEntity[]) {

--- a/src/modules/Dashboard/Debts/DebtsMetrics/DebtsMetrics.tsx
+++ b/src/modules/Dashboard/Debts/DebtsMetrics/DebtsMetrics.tsx
@@ -33,18 +33,20 @@ class DebtsMetrics extends React.Component<Props, State> {
 	}
 
 	componentDidMount() {
-		if (this.props.tokens && this.props.debtOrders) {
-			this.initiateTokenBalance(this.props.tokens, this.props.debtOrders);
+		this.initiateTokenBalance(this.props.tokens);
+	}
+
+	componentDidUpdate(prevProps: Props) {
+		if (this.props.tokens !== prevProps.tokens) {
+			this.initiateTokenBalance(this.props.tokens);
 		}
 	}
 
-	componentWillReceiveProps(nextProps: Props) {
-		if (nextProps.tokens && nextProps.debtOrders) {
-			this.initiateTokenBalance(nextProps.tokens, nextProps.debtOrders);
+	initiateTokenBalance(tokens: TokenEntity[]) {
+		if (!tokens || !tokens.length) {
+			return;
 		}
-	}
-
-	initiateTokenBalance(tokens: TokenEntity[], debtOrders: DebtOrderEntity[]) {
+		const { debtOrders } = this.props;
 		let tokenBalances: any = {};
 		for (let token of tokens) {
 			tokenBalances[token.tokenSymbol] = {

--- a/src/modules/Dashboard/Investments/InvestmentHistory/InvestmentRow.tsx
+++ b/src/modules/Dashboard/Investments/InvestmentHistory/InvestmentRow.tsx
@@ -35,18 +35,20 @@ class InvestmentRow extends React.Component<Props, State> {
 	}
 
 	async componentDidMount() {
-		if (this.props.dharma && this.props.investment) {
-			await this.determineStatus(this.props.dharma, this.props.investment);
+		await this.determineStatus(this.props.dharma);
+	}
+
+	async componentDidUpdate(prevProps: Props) {
+		if (this.props.dharma !== prevProps.dharma) {
+			await this.determineStatus(this.props.dharma);
 		}
 	}
 
-	async componentWillReceiveProps(nextProps: Props) {
-		if (nextProps.dharma && nextProps.investment) {
-			await this.determineStatus(nextProps.dharma, nextProps.investment);
+	async determineStatus(dharma: Dharma) {
+		const { investment } = this.props;
+		if (!dharma || !investment) {
+			return;
 		}
-	}
-
-	async determineStatus(dharma: Dharma, investment: InvestmentEntity) {
 		const earnedAmount = await dharma.servicing.getValueRepaid(investment.issuanceHash);
 		const expectedEarnedAmount = await dharma.servicing.getExpectedValueRepaid(investment.issuanceHash, moment().unix());
 		this.setState({

--- a/src/modules/Dashboard/Investments/Investments.tsx
+++ b/src/modules/Dashboard/Investments/Investments.tsx
@@ -31,8 +31,10 @@ class Investments extends React.Component<Props, State> {
 		this.getInvestmentsDetails(this.props.investments);
 	}
 
-	componentWillReceiveProps(nextProps: Props) {
-		this.getInvestmentsDetails(nextProps.investments);
+	componentDidUpdate(prevProps: Props) {
+		if (this.props.investments !== prevProps.investments) {
+			this.getInvestmentsDetails(this.props.investments);
+		}
 	}
 
 	async getInvestmentsDetails(investments: InvestmentEntity[]) {

--- a/src/modules/Dashboard/Investments/InvestmentsMetrics/InvestmentsMetrics.tsx
+++ b/src/modules/Dashboard/Investments/InvestmentsMetrics/InvestmentsMetrics.tsx
@@ -27,18 +27,20 @@ class InvestmentsMetrics extends React.Component<Props, State> {
     }
 
     componentDidMount() {
-        if (this.props.tokens && this.props.investments) {
-            this.initiateTokenBalance(this.props.tokens, this.props.investments);
+		this.initiateTokenBalance(this.props.tokens);
+    }
+
+    componentDidUpdate(prevProps: Props) {
+        if (this.props.tokens !== prevProps.tokens) {
+            this.initiateTokenBalance(this.props.tokens);
         }
     }
 
-    componentWillReceiveProps(nextProps: Props) {
-        if (nextProps.tokens && nextProps.investments) {
-            this.initiateTokenBalance(nextProps.tokens, nextProps.investments);
-        }
-    }
-
-    initiateTokenBalance(tokens: TokenEntity[], investments: InvestmentEntity[]) {
+    initiateTokenBalance(tokens: TokenEntity[]) {
+		const { investments } = this.props;
+		if (!tokens || !investments) {
+			return;
+		}
         let tokenBalances: any = {};
 		for (let token of tokens) {
 			tokenBalances[token.tokenSymbol] = {

--- a/src/modules/EnsureAgreedToTerms/EnsureAgreedToTerms.tsx
+++ b/src/modules/EnsureAgreedToTerms/EnsureAgreedToTerms.tsx
@@ -12,8 +12,8 @@ class EnsureAgreedToTerms extends React.Component<Props, {}> {
 		}
 	}
 
-	componentWillReceiveProps(nextProps: Props) {
-		if (!nextProps.agreeToTerms) {
+	componentDidUpdate(prevProps: Props) {
+		if (this.props.agreeToTerms !== prevProps.agreeToTerms && !this.props.agreeToTerms) {
 			browserHistory.push('/');
 		}
 	}

--- a/src/modules/FillLoan/FillLoanEntered/FillLoanEntered.tsx
+++ b/src/modules/FillLoan/FillLoanEntered/FillLoanEntered.tsx
@@ -72,19 +72,21 @@ class FillLoanEntered extends React.Component<Props, States> {
     }
 
     async componentDidMount() {
-        if (this.props.dharma && this.props.location.query) {
-            this.getDebtOrderDetail(this.props.dharma, this.props.location.query);
+		this.getDebtOrderDetail(this.props.dharma);
+    }
+
+    componentDidUpdate(prevProps: Props) {
+        if (this.props.dharma !== prevProps.dharma) {
+            this.getDebtOrderDetail(this.props.dharma);
         }
     }
 
-    componentWillReceiveProps(nextProps: Props) {
-        if (nextProps.dharma && nextProps.location.query) {
-            this.getDebtOrderDetail(nextProps.dharma, nextProps.location.query);
-        }
-    }
-
-    async getDebtOrderDetail(dharma: Dharma, urlParams: any) {
+    async getDebtOrderDetail(dharma: Dharma) {
         try {
+			const urlParams = this.props.location.query;
+			if (!dharma || !urlParams) {
+				return;
+			}
             const debtOrder = debtOrderFromJSON(JSON.stringify(urlParams));
             const description = debtOrder.description;
             const principalTokenSymbol = debtOrder.principalTokenSymbol;

--- a/src/modules/Welcome/Welcome.tsx
+++ b/src/modules/Welcome/Welcome.tsx
@@ -37,8 +37,8 @@ class Welcome extends React.Component<Props, State> {
 		}
 	}
 
-	componentWillReceiveProps(nextProps: Props) {
-		if (nextProps.agreeToTerms) {
+	componentDidUpdate(prevProps: Props) {
+		if (this.props.agreeToTerms !== prevProps.agreeToTerms && this.props.agreeToTerms) {
 			browserHistory.push('/request');
 		}
 	}


### PR DESCRIPTION
This PR introduces the following changes:

- Fix the issue where we were displaying duplicate debt order on the Dashboard page. It's because we didn't check whether a pending debt order has been filled and need to remove it from the pending list if necessary.
- Fix the issue on Dashboard where `componentWillReceiveProps` was in an infinite loop. As a result we were calling `getDebtsAsync` and `getInvestmentsAsync` indefinitely. Need to compare the next props and the current props.
- Clean up: Replace react's `componentWillReceiveProps` with `componentDidUpdate` since `componentWillReceiveProps` will be slowly deprecated. (https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html#fetching-external-data-when-props-change)