### PR TITLE
Check `dharma` or `accounts` for null before making API calls

### DIFF
--- a/src/common/web3Errors.ts
+++ b/src/common/web3Errors.ts
@@ -1,0 +1,14 @@
+const singleLineString = require("single-line-string");
+
+export const web3Errors = {
+    UNABLE_TO_FIND_ACCOUNTS: singleLineString`
+        Unable to find active account on current Ethereum network.  Make sure you are using
+        a Web3-enabled browser (such as Chrome with MetaMask installed), that you are connecting
+        to the Kovan testnet, and that your account is unlocked.
+    `,
+    UNABLE_TO_FIND_CONTRACTS: singleLineString`
+        Unable to find the Dharma smart contracts on the current Ethereum network.  Make sure you are using
+        a Web3-enabled browser (such as Chrome with MetaMask installed), that you are connecting
+        to the Kovan testnet, and that your account is unlocked.
+    `,
+};

--- a/src/components/TradingPermissions/TradingPermissions.tsx
+++ b/src/components/TradingPermissions/TradingPermissions.tsx
@@ -18,6 +18,7 @@ const promisify = require("tiny-promisify");
 import { Collapse } from "reactstrap";
 import { ClipLoader } from "react-spinners";
 import { truncate } from "src/utils/webUtils";
+import { web3Errors } from "../../common/web3Errors";
 
 interface Props {
     web3: Web3;
@@ -131,7 +132,13 @@ class TradingPermissions extends React.Component<Props, State> {
         this.props.toggleTokenLoadingSpinner(tokenAddress, true);
 
         try {
+			this.props.handleSetError('');
             const { tokens, dharma } = this.props;
+			if (!dharma) {
+				this.props.handleSetError(web3Errors.UNABLE_TO_FIND_CONTRACTS);
+				return;
+			}
+
             let selectedToken: TokenEntity | undefined = undefined;
             for (let token of tokens) {
                 if (token.address === tokenAddress) {
@@ -185,9 +192,18 @@ class TradingPermissions extends React.Component<Props, State> {
     }
 
     async handleFaucet(tokenAddress: string) {
+		this.props.handleSetError('');
         const { dharma } = this.props;
+		if (!dharma) {
+			this.props.handleSetError(web3Errors.UNABLE_TO_FIND_CONTRACTS);
+			return;
+		}
 
         const accounts = await promisify(this.props.web3.eth.getAccounts)();
+		if (!accounts.length) {
+			this.props.handleSetError(web3Errors.UNABLE_TO_FIND_ACCOUNTS);
+			return;
+		}
 
         return this.props.handleFaucetRequest(tokenAddress, accounts[0], dharma);
     }

--- a/src/modules/Dashboard/Debts/ActiveDebtOrder/ActiveDebtOrder.tsx
+++ b/src/modules/Dashboard/Debts/ActiveDebtOrder/ActiveDebtOrder.tsx
@@ -39,6 +39,7 @@ import { Row, Col, Collapse } from 'reactstrap';
 import { BigNumber } from 'bignumber.js';
 import Dharma from '@dharmaprotocol/dharma.js';
 import { TokenAmount } from "src/components";
+import { web3Errors } from "src/common/web3Errors";
 
 interface Props {
     debtOrder: DebtOrderEntity;
@@ -123,11 +124,15 @@ class ActiveDebtOrder extends React.Component<Props, State> {
 				handleSetErrorToast
 			} = this.props;
 
-			if (!accounts.length) {
-				handleSetErrorToast('Unable to find active account on Ethereum network');
+			handleSetErrorToast('');
+			if (!dharma) {
+				handleSetErrorToast(web3Errors.UNABLE_TO_FIND_CONTRACTS);
 				return;
-			}
-			if (!debtOrder.json) {
+			} else if (!accounts.length) {
+				handleSetErrorToast(web3Errors.UNABLE_TO_FIND_ACCOUNTS);
+				return;
+			} else if (!debtOrder.json) {
+				handleSetErrorToast("Unable to get debt order info");
 				return;
 			}
 
@@ -169,7 +174,12 @@ class ActiveDebtOrder extends React.Component<Props, State> {
 	}
 
     async handleRepaymentFormSubmission(tokenAmount: BigNumber, tokenSymbol: string) {
+		this.props.handleSetErrorToast('');
         const { dharma } = this.props;
+		if (!dharma) {
+			this.props.handleSetErrorToast(web3Errors.UNABLE_TO_FIND_CONTRACTS);
+			return;
+		}
 
         const tokenAddress = await dharma.contracts.getTokenAddressBySymbolAsync(tokenSymbol);
 
@@ -215,6 +225,9 @@ class ActiveDebtOrder extends React.Component<Props, State> {
 
     async calculatePaymentsMissed() {
         const { dharma } = this.props;
+		if (!dharma) {
+			return;
+		}
         const { issuanceHash, repaidAmount, repaymentSchedule } = this.props.debtOrder;
 
         let missedPayments = {};

--- a/src/modules/FillLoan/FillLoanEntered/FillLoanEntered.tsx
+++ b/src/modules/FillLoan/FillLoanEntered/FillLoanEntered.tsx
@@ -23,6 +23,7 @@ import Dharma from "@dharmaprotocol/dharma.js";
 import { DebtOrder } from "@dharmaprotocol/dharma.js/dist/types/src/types";
 import { BigNumber } from "bignumber.js";
 import { TokenEntity } from "../../../models";
+import { web3Errors } from "src/common/web3Errors";
 
 interface Props {
     location?: any;
@@ -118,6 +119,13 @@ class FillLoanEntered extends React.Component<Props, States> {
         try {
             this.props.handleSetError("");
             const { dharma, accounts } = this.props;
+			if (!dharma) {
+				this.props.handleSetError(web3Errors.UNABLE_TO_FIND_CONTRACTS);
+				return;
+			} else if (!accounts.length) {
+				this.props.handleSetError(web3Errors.UNABLE_TO_FIND_ACCOUNTS);
+				return;
+			}
             const { debtOrder, issuanceHash } = this.state;
 
             debtOrder.creditor = accounts[0];

--- a/src/modules/RequestLoan/RequestLoanForm/RequestLoanForm.tsx
+++ b/src/modules/RequestLoan/RequestLoanForm/RequestLoanForm.tsx
@@ -9,6 +9,7 @@ import Dharma from "@dharmaprotocol/dharma.js";
 import { BigNumber } from "bignumber.js";
 import { encodeUrlParams, debtOrderFromJSON, normalizeDebtOrder, withCommas } from "../../../utils";
 const BitlyClient = require("bitly");
+import { web3Errors } from "../../../common/web3Errors";
 
 interface Props {
     web3: Web3;
@@ -85,6 +86,14 @@ class RequestLoanForm extends React.Component<Props, State> {
             const { interestRate, amortizationUnit, termLength } = this.state.formData.terms;
             const { dharma, accounts } = this.props;
 
+			if (!this.props.dharma) {
+				this.props.handleSetError(web3Errors.UNABLE_TO_FIND_CONTRACTS);
+				return;
+			} else if (!this.props.accounts.length) {
+				this.props.handleSetError(web3Errors.UNABLE_TO_FIND_ACCOUNTS);
+				return;
+			}
+
             const simpleInterestLoan = {
                 principalTokenSymbol,
                 principalAmount: new BigNumber(principalAmount * 10 ** 18),
@@ -114,7 +123,13 @@ class RequestLoanForm extends React.Component<Props, State> {
             if (!this.state.debtOrder) {
                 this.props.handleSetError("No Debt Order has been generated yet");
                 return;
-            }
+			} else if (!this.props.dharma) {
+				this.props.handleSetError(web3Errors.UNABLE_TO_FIND_CONTRACTS);
+				return;
+			} else if (!this.props.accounts.length) {
+				this.props.handleSetError(web3Errors.UNABLE_TO_FIND_ACCOUNTS);
+				return;
+			}
 
             const { description, principalTokenSymbol, issuanceHash, bitly } = this.state;
             const debtOrder = debtOrderFromJSON(this.state.debtOrder);

--- a/src/router/router.tsx
+++ b/src/router/router.tsx
@@ -19,6 +19,7 @@ import { ParentContainer } from "../layouts";
 import * as Web3 from "web3";
 import { web3Connected, dharmaInstantiated, setAccounts } from "./actions";
 import { setError } from "../components/Toast/actions";
+import { web3Errors } from "../common/web3Errors";
 const promisify = require("tiny-promisify");
 
 // Import Dharma libraries
@@ -35,24 +36,9 @@ import {
     SimpleInterestTermsContract,
 } from "@dharmaprotocol/contracts";
 
-const singleLineString = require("single-line-string");
-
 interface Props {
     store: any;
 }
-
-const WEB3_ERRORS = {
-    UNABLE_TO_FIND_ACCOUNTS: singleLineString`
-        Unable to find active account on current Ethereum network.  Make sure you are using
-        a Web3-enabled browser (such as Chrome with MetaMask installed), that you are connecting
-        to the Kovan testnet, and that your account is unlocked.
-    `,
-    UNABLE_TO_FIND_CONTRACTS: singleLineString`
-        Unable to find the Dharma smart contracts on the current Ethereum network.  Make sure you are using
-        a Web3-enabled browser (such as Chrome with MetaMask installed), that you are connecting
-        to the Kovan testnet, and that your account is unlocked.
-    `,
-};
 
 class AppRouter extends React.Component<Props, {}> {
     constructor(props: Props) {
@@ -79,7 +65,7 @@ class AppRouter extends React.Component<Props, {}> {
         const accounts = await promisify(web3.eth.getAccounts)();
 
         if (!accounts.length) {
-            dispatch(setError(WEB3_ERRORS.UNABLE_TO_FIND_ACCOUNTS));
+            dispatch(setError(web3Errors.UNABLE_TO_FIND_ACCOUNTS));
             return;
         }
 
@@ -96,7 +82,7 @@ class AppRouter extends React.Component<Props, {}> {
                 networkId in SimpleInterestTermsContract.networks
             )
         ) {
-            dispatch(setError(WEB3_ERRORS.UNABLE_TO_FIND_CONTRACTS));
+            dispatch(setError(web3Errors.UNABLE_TO_FIND_CONTRACTS));
             return;
         }
         const dharmaConfig = {


### PR DESCRIPTION
This PR will fix issue where we are getting `Cannot read property adapter of null` error message in the UI.

I'm able to reproduce this error locally by unlocking metamask and then kill my ethereum testRPC. Metamask is still connected but the ethereum network is down.

To solve, add a simple check for null before making the API calls. Otherwise, display a more user-friendly error message.