### PR TITLE
Fix cancel button position and add loading spinner

### DIFF
--- a/src/components/ConfirmationModal/index.tsx
+++ b/src/components/ConfirmationModal/index.tsx
@@ -8,6 +8,7 @@ import {
 	ModalBody,
 	ModalFooter
 } from 'reactstrap';
+import { ClipLoader } from "react-spinners";
 
 interface Props {
 	modal: boolean;
@@ -18,6 +19,7 @@ interface Props {
 	onToggle: () => void;
 	onSubmit: () => void;
     disabled?: boolean;
+	awaitingTx?: boolean;
 }
 
 class ConfirmationModal extends React.Component<Props, {}> {
@@ -40,7 +42,7 @@ class ConfirmationModal extends React.Component<Props, {}> {
 	}
 
 	render() {
-		const { disabled } = this.props;
+		const { disabled, awaitingTx } = this.props;
 
 		return (
 			<div>
@@ -52,10 +54,13 @@ class ConfirmationModal extends React.Component<Props, {}> {
 					<ModalFooter>
 						<Row className="button-container">
 							<Col xs="12" md="6">
-								<Button className="button secondary width-95" disabled={!!disabled} onClick={this.handleToggle}>{this.props.closeButtonText}</Button>
+								<Button className="button secondary width-95" disabled={!!disabled || !!awaitingTx} onClick={this.handleToggle}>{this.props.closeButtonText}</Button>
 							</Col>
 							<Col xs="12" md="6" className="align-right">
-								<Button className="button width-95" disabled={!!disabled} onClick={this.handleSubmit}>{this.props.submitButtonText}</Button>
+								<Button className="button width-95" disabled={!!disabled || !!awaitingTx} onClick={this.handleSubmit}>
+									{this.props.submitButtonText}
+									<ClipLoader size={12} color={"#FFFFFF"} loading={!!awaitingTx} />
+								</Button>
 							</Col>
 						</Row>
 					</ModalFooter>

--- a/src/modules/Dashboard/Debts/ActiveDebtOrder/ActiveDebtOrder.tsx
+++ b/src/modules/Dashboard/Debts/ActiveDebtOrder/ActiveDebtOrder.tsx
@@ -31,6 +31,7 @@ import {
     Strikethrough,
     ShowMore,
     PaymentDate,
+	CancelButtonContainer,
 	CancelButton
 } from './styledComponents';
 import { MakeRepaymentModal, ConfirmationModal, Bold } from '../../../../components';
@@ -349,11 +350,6 @@ class ActiveDebtOrder extends React.Component<Props, State> {
                                         Make Repayment
                                     </MakeRepaymentButton>
                                 )}
-                                {debtOrder.status === "pending" && (
-									<CancelButton onClick={this.handleCancelDebtOrderClick}>
-									   Cancel
-									</CancelButton>
-								)}
                             </Col>
                         </Row>
                         {debtOrder.status === "active" ? (
@@ -363,12 +359,22 @@ class ActiveDebtOrder extends React.Component<Props, State> {
                         )}
                         <Terms>Simple Interest (Non-Collateralized)</Terms>
                     </DetailContainer>
-                    <RepaymentScheduleContainer
-                        className={debtOrder.status === "active" ? "active" : ""}
-                    >
-                        <Title>Repayment Schedule</Title>
-                        {repaymentScheduleItems}
-                    </RepaymentScheduleContainer>
+					{debtOrder.status === "pending" ?
+						(
+							<CancelButtonContainer>
+								<CancelButton onClick={this.handleCancelDebtOrderClick}>
+								Cancel
+								</CancelButton>
+							</CancelButtonContainer>
+						) : (
+							<RepaymentScheduleContainer
+								className={debtOrder.status === "active" ? "active" : ""}
+							>
+								<Title>Repayment Schedule</Title>
+								{repaymentScheduleItems}
+							</RepaymentScheduleContainer>
+						)
+					}
                 </Row>
                 <Collapse isOpen={this.state.collapse}>
                     <Drawer>
@@ -449,6 +455,7 @@ class ActiveDebtOrder extends React.Component<Props, State> {
 					onToggle={this.confirmationModalToggle}
 					onSubmit={this.handleCancelDebtOrderSubmission}
 					closeButtonText="No"
+					awaitingTx={this.state.awaitingCancelTx}
 					submitButtonText={
 						this.state.awaitingCancelTx ? "Canceling Order..." : "Yes"
 					}

--- a/src/modules/Dashboard/Debts/ActiveDebtOrder/styledComponents.tsx
+++ b/src/modules/Dashboard/Debts/ActiveDebtOrder/styledComponents.tsx
@@ -177,6 +177,17 @@ export const RepaymentScheduleContainer = styled(HalfCol)`
 	}
 `;
 
+export const CancelButtonContainer = RepaymentScheduleContainer.extend`
+	background-color: #FFFFFF;
+	display: block;
+
+	@media only screen and (max-width: 480px) {
+		float: none;
+		padding-top: 0px !important;
+		text-align: center;
+	}
+`;
+
 export const Title = styled.div`
 	color: #FFFFFF;
 	font-size: 13px;
@@ -433,4 +444,10 @@ export const MakeRepaymentButton = StyledButton.extend`
 export const CancelButton = MakeRepaymentButton.extend`
 	background-color: #1CC1CC !important;
 	border-color: #1CC1CC !important;
+
+	@media only screen and (max-width: 480px) {
+		font-size: 10px !important;
+		width: 100%;
+	}
+
 `;

--- a/src/modules/RequestLoan/RequestLoanForm/RequestLoanForm.tsx
+++ b/src/modules/RequestLoan/RequestLoanForm/RequestLoanForm.tsx
@@ -30,6 +30,7 @@ interface State {
     issuanceHash: string;
     confirmationModal: boolean;
     bitly: any;
+	awaitingSignTx: boolean;
 }
 
 class RequestLoanForm extends React.Component<Props, State> {
@@ -51,7 +52,8 @@ class RequestLoanForm extends React.Component<Props, State> {
             description: "",
             issuanceHash: "",
             confirmationModal: false,
-            bitly: null
+            bitly: null,
+			awaitingSignTx: false
         };
     }
 
@@ -131,6 +133,7 @@ class RequestLoanForm extends React.Component<Props, State> {
 				this.props.handleSetError(web3Errors.UNABLE_TO_FIND_ACCOUNTS);
 				return;
 			}
+			this.setState({ awaitingSignTx: true });
 
             const { description, principalTokenSymbol, issuanceHash, bitly } = this.state;
             const debtOrder = debtOrderFromJSON(this.state.debtOrder);
@@ -141,6 +144,7 @@ class RequestLoanForm extends React.Component<Props, State> {
 
             this.setState({
                 debtOrder: JSON.stringify(debtOrder),
+				awaitingSignTx: false,
                 confirmationModal: false
             });
 
@@ -189,6 +193,7 @@ class RequestLoanForm extends React.Component<Props, State> {
 			}
 
             this.setState({
+				awaitingSignTx: false,
                 confirmationModal: false
             });
             return;
@@ -264,15 +269,18 @@ class RequestLoanForm extends React.Component<Props, State> {
 						transformErrors={this.transformErrors}
 					/>
                 </MainWrapper>
-                <ConfirmationModal
-                    modal={this.state.confirmationModal}
-                    title="Please confirm"
-                    content={confirmationModalContent}
-                    onToggle={this.confirmationModalToggle}
-                    onSubmit={this.handleSignDebtOrder}
-                    closeButtonText="&#8592; Modify Request"
-                    submitButtonText="Complete Request"
-                />
+				<ConfirmationModal
+					modal={this.state.confirmationModal}
+					title="Please confirm"
+					content={confirmationModalContent}
+					onToggle={this.confirmationModalToggle}
+					onSubmit={this.handleSignDebtOrder}
+					closeButtonText="&#8592; Modify Request"
+					submitButtonText={
+						this.state.awaitingSignTx ? "Completing Request..." : "Complete Request"
+					}
+					awaitingTx={this.state.awaitingSignTx}
+				/>
             </PaperLayout>
         );
     }


### PR DESCRIPTION
This PR introduces the following changes:

- Reposition Cancel button and move it all the way to the right
- When cancelling a debt order, disable the button and show loading spinner
- In addition, when requesting a debt order, disable the button and show loading spinner