### PR TITLE
build: use 2 workers max for circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,4 +14,4 @@ jobs:
         - run: sleep 6
         - run: yarn contracts:migrate
         - run: yarn migrations:loans
-        - run: yarn jest
+        - run: yarn jest --maxWorkers 2


### PR DESCRIPTION
Jest will greedily parallelize tests, which can create problems on circle -- see: https://discuss.circleci.com/t/memory-problems-with-jest-and-workers/10297

So this should set some bounds on the memory usage.