### PR TITLE
Fix: remove @dharmaprotocol/contracts, rely on dharma.js instead

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@dharmaprotocol/contracts": "0.0.32",
     "@dharmaprotocol/dharma.js": "0.0.44",
     "@types/bignumber.js": "^5.0.0",
     "@types/deep-diff": "^0.0.31",
@@ -82,7 +81,7 @@
   },
   "scripts": {
     "contracts:migrate": "bash contract-scripts/migrate_dharma_contracts.sh",
-    "chain": "ganache-cli -m 'pink proof foil skull tide narrow audit card rotate forget liar favorite'",
+    "chain": "ganache-cli -m 'pink proof foil skull tide narrow audit card rotate forget liar favorite' -i 1457",
     "deploy": "npm run build && aws s3 sync build s3://plex.dharma.io --cache-control 'no-cache, no-store' --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers",
     "start": "node scripts/start.js --history-api-fallback",
     "build": "node scripts/build.js",

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -1,0 +1,4 @@
+export const KOVAN_NETWORK_ID = 42;
+export const LOCAL_NETWORK_ID = 1457;
+
+export const SUPPORTED_NETWORK_IDS = new Array(KOVAN_NETWORK_ID, LOCAL_NETWORK_ID);

--- a/yarn.lock
+++ b/yarn.lock
@@ -31,12 +31,6 @@
     lodash "^4.2.0"
     to-fast-properties "^2.0.0"
 
-"@dharmaprotocol/contracts@0.0.32":
-  version "0.0.32"
-  resolved "https://registry.yarnpkg.com/@dharmaprotocol/contracts/-/contracts-0.0.32.tgz#ae41ef1804d5244dcf000a2b18c95f45dfb9a677"
-  dependencies:
-    zeppelin-solidity "^1.8.0"
-
 "@dharmaprotocol/contracts@0.0.34":
   version "0.0.34"
   resolved "https://registry.yarnpkg.com/@dharmaprotocol/contracts/-/contracts-0.0.34.tgz#17f9ecb27588f0558dfc554153466a5c3b3f26d5"


### PR DESCRIPTION
This PR introduces the following changes:

- Removes the explicit `@dharmaprotocol/contracts` dependency from Plex, given that the contracts are loaded by default in dharma.js.  It will still be in the dependency tree, given that `@dharmaprotocol/dharma.js` depends on it.
- Rewrites the dharma initialization logic to no longer depend on passing a configuration of contracts manually.

### Context 
The manual passing in of contracts in Plex is a vestige of the `dharma-react-starter-kit` code, which would actually compile and migrate contract code in the same root directory as the React app, meaning contract artifacts had to be manually passed into the dharma libraries.  The migration scripts we've been using in Plex no longer rely on any such assumption (they actually go into the `@dharmaprotocol/contracts` repo and migrate the contracts from there).  We want to remove this initialization logic because it makes contract version upgrades more confusing in Plex -- we have to update both `@dharmaprotocol/dharma.js` and `@dharmaprotocol/contracts`.  This is easy to forget and idiosyncratic.  