### PR TITLE
build: bump dharma.js to 0.0.45

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@dharmaprotocol/dharma.js": "0.0.44",
+    "@dharmaprotocol/dharma.js": "0.0.45",
     "@types/bignumber.js": "^5.0.0",
     "@types/deep-diff": "^0.0.31",
     "@types/enzyme": "^3.1.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -31,17 +31,17 @@
     lodash "^4.2.0"
     to-fast-properties "^2.0.0"
 
-"@dharmaprotocol/contracts@0.0.34":
-  version "0.0.34"
-  resolved "https://registry.yarnpkg.com/@dharmaprotocol/contracts/-/contracts-0.0.34.tgz#17f9ecb27588f0558dfc554153466a5c3b3f26d5"
+"@dharmaprotocol/contracts@0.0.35":
+  version "0.0.35"
+  resolved "https://registry.yarnpkg.com/@dharmaprotocol/contracts/-/contracts-0.0.35.tgz#0fd334285447363715bdddf6022ac03066d8e3c2"
   dependencies:
     zeppelin-solidity "^1.8.0"
 
-"@dharmaprotocol/dharma.js@0.0.44":
-  version "0.0.44"
-  resolved "https://registry.yarnpkg.com/@dharmaprotocol/dharma.js/-/dharma.js-0.0.44.tgz#e7b13e27a4004be4d26cf9b8d53d43387bf74baf"
+"@dharmaprotocol/dharma.js@0.0.45":
+  version "0.0.45"
+  resolved "https://registry.yarnpkg.com/@dharmaprotocol/dharma.js/-/dharma.js-0.0.45.tgz#09b2680ecb38a1401a63825699793c93679f9b39"
   dependencies:
-    "@dharmaprotocol/contracts" "0.0.34"
+    "@dharmaprotocol/contracts" "0.0.35"
     "@types/lodash" "^4.14.104"
     abi-decoder "https://github.com/dharmaprotocol/abi-decoder"
     bignumber.js "^5.0.0"


### PR DESCRIPTION
This PR introduces the following changes:

- bumps the `dharma.js` version to 0.0.45 to fix issues that emerged in the `contracts`' v0.0.34 deployment.