### PR TITLE
Fix `cannot read property push of undefined`

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@dharmaprotocol/dharma.js": "0.0.45",
+    "@dharmaprotocol/dharma.js": "0.0.46",
     "@types/bignumber.js": "^5.0.0",
     "@types/deep-diff": "^0.0.31",
     "@types/enzyme": "^3.1.9",
@@ -81,8 +81,10 @@
   },
   "scripts": {
     "contracts:migrate": "bash contract-scripts/migrate_dharma_contracts.sh",
-    "chain": "ganache-cli -m 'pink proof foil skull tide narrow audit card rotate forget liar favorite' -i 1457",
-    "deploy": "npm run build && aws s3 sync build s3://plex.dharma.io --cache-control 'no-cache, no-store' --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers",
+    "chain":
+      "ganache-cli -m 'pink proof foil skull tide narrow audit card rotate forget liar favorite' -i 1457",
+    "deploy":
+      "npm run build && aws s3 sync build s3://plex.dharma.io --cache-control 'no-cache, no-store' --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers",
     "start": "node scripts/start.js --history-api-fallback",
     "build": "node scripts/build.js",
     "test:watch": "jest --watch --runInBand",
@@ -108,26 +110,15 @@
       ".(ts|tsx)": "<rootDir>/node_modules/ts-jest/preprocessor.js"
     },
     "testRegex": "(/__test__/.*|\\.(test|spec))\\.(ts|tsx|js)$",
-    "moduleFileExtensions": [
-      "ts",
-      "tsx",
-      "js"
-    ],
+    "moduleFileExtensions": ["ts", "tsx", "js"],
     "moduleNameMapper": {
-      "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/__mocks__/fileMock.js",
+      "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$":
+        "<rootDir>/__mocks__/fileMock.js",
       "\\.(css|less)$": "<rootDir>/__mocks__/styleMock.js"
     },
-    "modulePaths": [
-      "<rootDir>/"
-    ],
-    "coveragePathIgnorePatterns": [
-      "/node_modules/",
-      "/test/"
-    ],
-    "testPathIgnorePatterns": [
-      "<rootDir>/__test__/setup.js",
-      "/build/dist/"
-    ],
+    "modulePaths": ["<rootDir>/"],
+    "coveragePathIgnorePatterns": ["/node_modules/", "/test/"],
+    "testPathIgnorePatterns": ["<rootDir>/__test__/setup.js", "/build/dist/"],
     "coverageThreshold": {
       "global": {
         "branches": 35,
@@ -153,11 +144,7 @@
     ],
     "mapCoverage": true,
     "setupTestFrameworkScriptFile": "./__test__/setup.js",
-    "unmockedModulePathPatterns": [
-      "react",
-      "enzyme",
-      "jest-enzyme"
-    ],
+    "unmockedModulePathPatterns": ["react", "enzyme", "jest-enzyme"],
     "testURL": "http://localhost"
   }
 }

--- a/src/models/LocalStorage.ts
+++ b/src/models/LocalStorage.ts
@@ -14,6 +14,16 @@ export const loadState = () => {
             state.debtOrderReducer.debtOrders,
         );
 
+        // TODO(kayvon): set default values for those properties of `state` that are not saved to
+        // local storage.
+        if (!state.debtOrderReducer.pendingDebtOrderIssuanceHashes) {
+            state.debtOrderReducer.pendingDebtOrderIssuanceHashes = [];
+        }
+
+        if (!state.debtOrderReducer.filledDebtOrderIssuanceHashes) {
+            state.debtOrderReducer.filledDebtOrderIssuanceHashes = [];
+        }
+
         return state;
     } catch (err) {
         return undefined;

--- a/yarn.lock
+++ b/yarn.lock
@@ -205,9 +205,9 @@ abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
 
-"abi-decoder@git+https://github.com/dharmaprotocol/abi-decoder.git":
+"abi-decoder@https://github.com/dharmaprotocol/abi-decoder":
   version "1.1.0"
-  resolved "git+https://github.com/dharmaprotocol/abi-decoder.git#9448e51a134633673ccbb07a3df0ed2b0c47ab62"
+  resolved "https://github.com/dharmaprotocol/abi-decoder#9448e51a134633673ccbb07a3df0ed2b0c47ab62"
   dependencies:
     babel-core "^6.23.1"
     babel-loader "^6.3.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -37,9 +37,9 @@
   dependencies:
     zeppelin-solidity "^1.8.0"
 
-"@dharmaprotocol/dharma.js@0.0.45":
-  version "0.0.45"
-  resolved "https://registry.yarnpkg.com/@dharmaprotocol/dharma.js/-/dharma.js-0.0.45.tgz#09b2680ecb38a1401a63825699793c93679f9b39"
+"@dharmaprotocol/dharma.js@0.0.46":
+  version "0.0.46"
+  resolved "https://registry.yarnpkg.com/@dharmaprotocol/dharma.js/-/dharma.js-0.0.46.tgz#30e1897ebc27ec35a56f9453327f98327f0b6172"
   dependencies:
     "@dharmaprotocol/contracts" "0.0.35"
     "@types/lodash" "^4.14.104"
@@ -205,9 +205,9 @@ abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
 
-"abi-decoder@https://github.com/dharmaprotocol/abi-decoder":
+"abi-decoder@git+https://github.com/dharmaprotocol/abi-decoder.git":
   version "1.1.0"
-  resolved "https://github.com/dharmaprotocol/abi-decoder#9448e51a134633673ccbb07a3df0ed2b0c47ab62"
+  resolved "git+https://github.com/dharmaprotocol/abi-decoder.git#9448e51a134633673ccbb07a3df0ed2b0c47ab62"
   dependencies:
     babel-core "^6.23.1"
     babel-loader "^6.3.2"


### PR DESCRIPTION
This PR addresses the error @nadavhollander was seeing when attempting to generate a loan order.

Essentially, we need to introduce some form of schema versioning for the models we write to local storage. @chrismin is going to create a pivotal story to address the larger issues at play here.

Original error here: https://cl.ly/3t2038012q47