### PR TITLE
feat: remove ability to fill loans with REP

### DIFF
--- a/react-ui/src/common/constants.ts
+++ b/react-ui/src/common/constants.ts
@@ -13,6 +13,8 @@ export const ETH_GAS_STATION_API_URL = "https://ethgasstation.info/json/ethgasAP
 export const COIN_MARKET_CAP_LISTINGS_API_URL = "https://api.coinmarketcap.com/v2/listings/";
 export const COIN_MARKET_CAP_TICKER_API_URL = "https://api.coinmarketcap.com/v2/ticker/";
 
+export const FROZEN_TOKENS = [ "REP" ];
+
 export const SUPPORTED_NETWORK_IDS = new Array(
     KOVAN_NETWORK_ID,
     LOCAL_NETWORK_ID,

--- a/react-ui/src/common/constants.ts
+++ b/react-ui/src/common/constants.ts
@@ -13,7 +13,7 @@ export const ETH_GAS_STATION_API_URL = "https://ethgasstation.info/json/ethgasAP
 export const COIN_MARKET_CAP_LISTINGS_API_URL = "https://api.coinmarketcap.com/v2/listings/";
 export const COIN_MARKET_CAP_TICKER_API_URL = "https://api.coinmarketcap.com/v2/ticker/";
 
-export const FROZEN_TOKENS = [ "REP" ];
+export const FROZEN_TOKENS = ["REP"];
 
 export const SUPPORTED_NETWORK_IDS = new Array(
     KOVAN_NETWORK_ID,

--- a/react-ui/src/modules/FillLoan/FillLoanEntered/FillLoanEntered.tsx
+++ b/react-ui/src/modules/FillLoan/FillLoanEntered/FillLoanEntered.tsx
@@ -31,9 +31,10 @@ import { Dharma, Types } from "@dharmaprotocol/dharma.js";
 import { BigNumber } from "bignumber.js";
 import { OpenCollateralizedDebtEntity, TokenEntity } from "../../../models";
 import { web3Errors } from "src/common/web3Errors";
-import { BLOCKCHAIN_API } from "../../../common/constants";
+import { BLOCKCHAIN_API, FROZEN_TOKENS } from "../../../common/constants";
 import { BarLoader } from "react-spinners";
 import { CollateralizedSimpleInterestTermsContractParameters } from "@dharmaprotocol/dharma.js/dist/types/src/adapters/collateralized_simple_interest_loan_adapter";
+import FrozenTokenWarning from "./FrozenTokenWarning";
 
 const ERROR_MESSAGE_MAPPING = {
     "User denied transaction signature": "Wallet has denied transaction.",
@@ -349,6 +350,9 @@ class FillLoanEntered extends React.Component<Props, States> {
             );
         }
 
+        const isTokenFrozen = _.includes(FROZEN_TOKENS, principalTokenAmount.tokenSymbol) ||
+            _.includes(FROZEN_TOKENS, collateralTokenAmount.tokenSymbol);
+
         const leftInfoItems = [
             {
                 title: "Principal",
@@ -394,12 +398,14 @@ class FillLoanEntered extends React.Component<Props, States> {
             </InfoItem>
         ));
 
-        const descriptionContent = (
-            <span>
-                Here are the details of loan request <Bold>{issuanceHash}</Bold>. If the terms look
-                fair to you, fill the loan and your transaction will be completed.
-            </span>
-        );
+        const descriptionContent = isTokenFrozen
+            ? <FrozenTokenWarning tokenName={principalTokenAmount.tokenName}/>
+            : (
+                <span>
+                    Here are the details of loan request <Bold>{issuanceHash}</Bold>. If the terms look
+                    fair to you, fill the loan and your transaction will be completed.
+                </span>
+            );
         return (
             <PaperLayout>
                 <MainWrapper>
@@ -414,17 +420,22 @@ class FillLoanEntered extends React.Component<Props, States> {
                             </InfoItem>
                         </Col>
                     </LoanInfoContainer>
-                    <ButtonContainer>
-                        <Link to="/fill">
-                            <DeclineButton>Decline</DeclineButton>
-                        </Link>
-                        <FillLoanButton
-                            onClick={this.confirmationModalToggle}
-                            disabled={this.state.awaitingTransaction}
-                        >
-                            Fill Loan
-                        </FillLoanButton>
-                    </ButtonContainer>
+
+                    {
+                        isTokenFrozen
+                            ? null
+                            : <ButtonContainer>
+                                <Link to="/fill">
+                                    <DeclineButton>Decline</DeclineButton>
+                                </Link>
+                                <FillLoanButton
+                                    onClick={this.confirmationModalToggle}
+                                    disabled={this.state.awaitingTransaction}
+                                >
+                                    Fill Loan
+                                </FillLoanButton>
+                            </ButtonContainer>
+                    }
 
                     {this.state.awaitingTransaction && (
                         <Content style={{ textAlign: "center" }}>

--- a/react-ui/src/modules/FillLoan/FillLoanEntered/FillLoanEntered.tsx
+++ b/react-ui/src/modules/FillLoan/FillLoanEntered/FillLoanEntered.tsx
@@ -350,7 +350,8 @@ class FillLoanEntered extends React.Component<Props, States> {
             );
         }
 
-        const isTokenFrozen = _.includes(FROZEN_TOKENS, principalTokenAmount.tokenSymbol) ||
+        const isTokenFrozen =
+            _.includes(FROZEN_TOKENS, principalTokenAmount.tokenSymbol) ||
             _.includes(FROZEN_TOKENS, collateralTokenAmount.tokenSymbol);
 
         const leftInfoItems = [
@@ -398,14 +399,14 @@ class FillLoanEntered extends React.Component<Props, States> {
             </InfoItem>
         ));
 
-        const descriptionContent = isTokenFrozen
-            ? <FrozenTokenWarning tokenName={principalTokenAmount.tokenName}/>
-            : (
-                <span>
-                    Here are the details of loan request <Bold>{issuanceHash}</Bold>. If the terms look
-                    fair to you, fill the loan and your transaction will be completed.
-                </span>
-            );
+        const descriptionContent = isTokenFrozen ? (
+            <FrozenTokenWarning tokenName={principalTokenAmount.tokenName} />
+        ) : (
+            <span>
+                Here are the details of loan request <Bold>{issuanceHash}</Bold>. If the terms look
+                fair to you, fill the loan and your transaction will be completed.
+            </span>
+        );
         return (
             <PaperLayout>
                 <MainWrapper>
@@ -421,21 +422,19 @@ class FillLoanEntered extends React.Component<Props, States> {
                         </Col>
                     </LoanInfoContainer>
 
-                    {
-                        isTokenFrozen
-                            ? null
-                            : <ButtonContainer>
-                                <Link to="/fill">
-                                    <DeclineButton>Decline</DeclineButton>
-                                </Link>
-                                <FillLoanButton
-                                    onClick={this.confirmationModalToggle}
-                                    disabled={this.state.awaitingTransaction}
-                                >
-                                    Fill Loan
-                                </FillLoanButton>
-                            </ButtonContainer>
-                    }
+                    {isTokenFrozen ? null : (
+                        <ButtonContainer>
+                            <Link to="/fill">
+                                <DeclineButton>Decline</DeclineButton>
+                            </Link>
+                            <FillLoanButton
+                                onClick={this.confirmationModalToggle}
+                                disabled={this.state.awaitingTransaction}
+                            >
+                                Fill Loan
+                            </FillLoanButton>
+                        </ButtonContainer>
+                    )}
 
                     {this.state.awaitingTransaction && (
                         <Content style={{ textAlign: "center" }}>

--- a/react-ui/src/modules/FillLoan/FillLoanEntered/FrozenTokenWarning.tsx
+++ b/react-ui/src/modules/FillLoan/FillLoanEntered/FrozenTokenWarning.tsx
@@ -1,0 +1,20 @@
+import * as React from "react";
+
+import { FrozenTokenWarningWrapper } from "./styledComponents";
+
+interface Props {
+    tokenName: string;
+}
+
+export default class FrozenTokenWarning extends React.Component<Props, {}> {
+    render() {
+        const { tokenName } = this.props;
+
+        return (
+            <FrozenTokenWarningWrapper>
+                The {tokenName} token in this order is currently frozen. Therefore, we
+                are unable to fill this order at present.
+            </FrozenTokenWarningWrapper>
+        );
+    }
+}

--- a/react-ui/src/modules/FillLoan/FillLoanEntered/FrozenTokenWarning.tsx
+++ b/react-ui/src/modules/FillLoan/FillLoanEntered/FrozenTokenWarning.tsx
@@ -12,8 +12,8 @@ export default class FrozenTokenWarning extends React.Component<Props, {}> {
 
         return (
             <FrozenTokenWarningWrapper>
-                The {tokenName} token in this order is currently frozen. Therefore, we
-                are unable to fill this order at present.
+                The {tokenName} token in this order is currently frozen. Therefore, we are unable to
+                fill this order at present.
             </FrozenTokenWarningWrapper>
         );
     }

--- a/react-ui/src/modules/FillLoan/FillLoanEntered/FrozenTokenWarning.tsx
+++ b/react-ui/src/modules/FillLoan/FillLoanEntered/FrozenTokenWarning.tsx
@@ -12,8 +12,8 @@ export default class FrozenTokenWarning extends React.Component<Props, {}> {
 
         return (
             <FrozenTokenWarningWrapper>
-                The {tokenName} token in this order is currently frozen. Therefore, we are unable to
-                fill this order at present.
+                The lending of {tokenName} token is temporarily currently frozen on Plex.
+                Therefore, we are unable to fill this order at present.
             </FrozenTokenWarningWrapper>
         );
     }

--- a/react-ui/src/modules/FillLoan/FillLoanEntered/styledComponents.tsx
+++ b/react-ui/src/modules/FillLoan/FillLoanEntered/styledComponents.tsx
@@ -41,6 +41,19 @@ export const InfoItem = styled.div`
     }
 `;
 
+export const FrozenTokenWarningWrapper = styled.div`
+    margin: 30px 0;
+    padding: 10px;
+    
+    font-family: DIN-Bold;
+    font-size: 17px;
+    text-align: center;
+    
+    
+    color: #002326;
+    background-color: #e93d59;
+`;
+
 export const Title = styled.div`
     font-family: DIN-Bold;
     opacity: 0.5;

--- a/react-ui/src/modules/FillLoan/FillLoanEntered/styledComponents.tsx
+++ b/react-ui/src/modules/FillLoan/FillLoanEntered/styledComponents.tsx
@@ -44,12 +44,11 @@ export const InfoItem = styled.div`
 export const FrozenTokenWarningWrapper = styled.div`
     margin: 30px 0;
     padding: 10px;
-    
+
     font-family: DIN-Bold;
     font-size: 17px;
     text-align: center;
-    
-    
+
     color: #002326;
     background-color: #e93d59;
 `;


### PR DESCRIPTION
Regular fill order modal:
<img width="734" alt="screen shot 2018-07-05 at 6 36 16 pm" src="https://user-images.githubusercontent.com/36094097/42355582-a86714c6-8082-11e8-8668-534a43fb5957.png">

Modal for order with REP:
<img width="705" alt="screen shot 2018-07-05 at 6 33 47 pm" src="https://user-images.githubusercontent.com/36094097/42355583-a87cd36a-8082-11e8-922f-0714407bef63.png">
